### PR TITLE
fix: add requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+certifi==2024.8.30
+charset-normalizer==3.4.0
+dbus-python==1.3.2
+idna==3.10
+pycairo==1.27.0
+pygobject==3.50.0
+requests==2.32.3
+urllib3==2.2.3


### PR DESCRIPTION
These packages are required to run app.py with python 3.9.0